### PR TITLE
do not assume that jar does not exist in sdk dir even though ivy file…

### DIFF
--- a/src/main/java/org/moe/gradle/MoePlugin.java
+++ b/src/main/java/org/moe/gradle/MoePlugin.java
@@ -20,6 +20,7 @@ import org.apache.tools.ant.taskdefs.condition.Os;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.JavaPlugin;
@@ -124,7 +125,7 @@ public class MoePlugin extends AbstractMoePlugin {
                 throw new GradleException("Failed to add Multi-OS Engine SDK repo", e);
             }
             ivy.artifactPattern(ivy.getUrl() + "/[artifact](-[classifier])(.[ext])");
-        });
+        }).metadataSources(IvyArtifactRepository.MetadataSources::artifact);
         project.getRepositories().ivy(ivy -> {
             ivy.setName("multi-os-engine-implicit-tools-repo");
             try {
@@ -133,7 +134,7 @@ public class MoePlugin extends AbstractMoePlugin {
                 throw new GradleException("Failed to add Multi-OS Engine Tools repo", e);
             }
             ivy.artifactPattern(ivy.getUrl() + "/[artifact](-[classifier])(.[ext])");
-        });
+        }).metadataSources(IvyArtifactRepository.MetadataSources::artifact);
 
         project.getDependencies().add(JavaPlugin.COMPILE_CONFIGURATION_NAME,
                 FileUtils.getNameAsArtifact(getSDK().getCoreJar(), getSDK().sdkVersion));

--- a/src/main/java/org/moe/gradle/MoeSDKPlugin.java
+++ b/src/main/java/org/moe/gradle/MoeSDKPlugin.java
@@ -19,6 +19,7 @@ package org.moe.gradle;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.JavaPlugin;
@@ -89,7 +90,7 @@ public class MoeSDKPlugin extends AbstractMoePlugin {
                 throw new GradleException("Failed to add Multi-OS Engine repo", e);
             }
             ivy.artifactPattern(ivy.getUrl() + "/[artifact](-[classifier])(.[ext])");
-        });
+        }).metadataSources(IvyArtifactRepository.MetadataSources::artifact);
 
         project.getDependencies().add(JavaPlugin.COMPILE_CONFIGURATION_NAME,
                 FileUtils.getNameAsArtifact(getSDK().getCoreJar(), getSDK().sdkVersion));


### PR DESCRIPTION
… is not there

If Gradle fails to locate the metadata file (.pom or ivy.xml) of a module in a repository, since version 6.0 it assumes that the module does not exist in that repository. Opt into the old behavior for selected repositories by adding the artifact() metadata source.

https://docs.gradle.org/current/userguide/upgrading_version_5.html#maven_or_ivy_repositories_are_no_longer_queried_for_artifacts_without_metadata_by_default